### PR TITLE
Fix CPX UART baud rate

### DIFF
--- a/main/uart_transport.c
+++ b/main/uart_transport.c
@@ -199,7 +199,7 @@ void uart_transport_init() {
     evGroup = xEventGroupCreate();
 
     const uart_config_t uart_config = {
-        .baud_rate = 115200,
+        .baud_rate = 576000,
         .data_bits = UART_DATA_8_BITS,
         .parity = UART_PARITY_DISABLE,
         .stop_bits = UART_STOP_BITS_1,


### PR DESCRIPTION
This PR increases the baud rate to match the STM32 (unlike #16) which actually set the debug print UART baudrate.