### PR TITLE
Log (STA) Mac regardless of Wifi cfg

### DIFF
--- a/main/discovery.c
+++ b/main/discovery.c
@@ -31,11 +31,14 @@
 static char hostname[14];
 static char macString[13];
 
+/* Log printout tag */
+static const char *TAG = "DISCOVERY";
+
 void discovery_init()
 {
     esp_err_t err = mdns_init();
     if (err) {
-        ESP_LOGW("DISCOVERY", "Init failed: %d", err);
+        ESP_LOGW(TAG, "Init failed: %d", err);
         return;
     }
 
@@ -45,25 +48,26 @@ void discovery_init()
     snprintf(hostname, sizeof(hostname), "aideck-%02X%02X%02X", mac[3], mac[4], mac[5]);
     snprintf(macString, sizeof(macString), "%02X%02X%02X%02X%02X%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
-    ESP_LOGI("DISCOVERY", "Hostname is %s", hostname);
+    ESP_LOGI(TAG, "Hostname is %s", hostname);
+    ESP_LOGI(TAG, "MAC (STA) is %x:%x:%x:%x:%x:%x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
     if (mdns_hostname_set(hostname) != ESP_OK) {
-      ESP_LOGW("DISCOVERY", "Could not set hostname");
+      ESP_LOGW(TAG, "Could not set hostname");
       return;
     }
     
     if (mdns_instance_name_set("AI-deck") != ESP_OK) {
-      ESP_LOGW("DISCOVERY", "Could not set instance name");
+      ESP_LOGW(TAG, "Could not set instance name");
       return;
     }
 
     if (mdns_service_add(NULL, "_cpx", "_tcp", 5000, NULL, 0) != ESP_OK) {
-      ESP_LOGW("DISCOVERY", "Could not add service");
+      ESP_LOGW(TAG, "Could not add service");
       return;
     }
 
     if (mdns_service_instance_name_set("_cpx", "_tcp", "Crazyflie Packet eXchange") != ESP_OK) {
-      ESP_LOGW("DISCOVERY", "Could not set service instance name");
+      ESP_LOGW(TAG, "Could not set service instance name");
       return;
     }  
 
@@ -75,7 +79,7 @@ void discovery_init()
         {"cpxversion", "1"}
     };
     if (mdns_service_txt_set("_cpx", "_tcp", serviceTxtData, 5) != ESP_OK) {
-      ESP_LOGW("DISCOVERY", "Could not set txt data");
+      ESP_LOGW(TAG, "Could not set txt data");
       return;
     }
 }


### PR DESCRIPTION
* Simplifies adding an AI deck to a network with MAC filters
* Refactor: Use a static const TAG string for consistency