### PR TITLE
Added CPX version

### DIFF
--- a/main/cpx.c
+++ b/main/cpx.c
@@ -1,19 +1,25 @@
 #include "cpx.h"
+#include "freertos/FreeRTOS.h"
 
 void cpxInitRoute(const CPXTarget_t source, const CPXTarget_t destination, const CPXFunction_t function, CPXRouting_t* route) {
     route->source = source;
     route->destination = destination;
     route->function = function;
+    route->version = CPX_VERSION;
 }
 
 void cpxRouteToPacked(const CPXRouting_t* route, CPXRoutingPacked_t* packed) {
     packed->source = route->source;
     packed->destination = route->destination;
     packed->function = route->function;
+    packed->version = route->version;
     packed->lastPacket = route->lastPacket;
 }
 
 void cpxPackedToRoute(const CPXRoutingPacked_t* packed, CPXRouting_t* route) {
+    assert(CPX_VERSION == packed->version);
+
+    route->version = packed->version;
     route->source = packed->source;
     route->destination = packed->destination;
     route->function = packed->function;

--- a/main/cpx.h
+++ b/main/cpx.h
@@ -27,6 +27,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#define CPX_VERSION (0)
+
 // This enum is used to identify source and destination for CPX routing information
 typedef enum {
   CPX_T_STM32 = 1, // The STM in the Crazyflie
@@ -50,6 +52,7 @@ typedef struct {
   CPXTarget_t source;
   bool lastPacket;
   CPXFunction_t function;
+  uint8_t version;
 } CPXRouting_t;
 
 // This struct contains routing information in a packed format. This struct
@@ -60,7 +63,8 @@ typedef struct {
   CPXTarget_t source : 3;
   bool lastPacket : 1;
   bool reserved : 1;
-  CPXFunction_t function : 8;
+  CPXFunction_t function : 6;
+  uint8_t version : 2;
 } __attribute__((packed)) CPXRoutingPacked_t;
 
 #define CPX_ROUTING_PACKED_SIZE (sizeof(CPXRoutingPacked_t))

--- a/main/router.c
+++ b/main/router.c
@@ -94,6 +94,9 @@ static void route(Receiver_t receive, CPXRoutablePacket_t* rxp, RouteContext_t* 
   while(1) {
     receive(rxp);
 
+    // The version should already be checked when we receive packets. Do it again to make sure.
+    assert(CPX_VERSION == rxp->route.version);
+
     const CPXTarget_t source = rxp->route.source;
     const CPXTarget_t destination = rxp->route.destination;
     const uint16_t cpxDataLength = rxp->dataLength;


### PR DESCRIPTION
This PR adds a version check to the CPX header. 
The change should be backwards compatible. 

Closes #19