### PR TITLE
Adds error LED blinking

### DIFF
--- a/main/aideck_esp_main.c
+++ b/main/aideck_esp_main.c
@@ -43,6 +43,7 @@
 #include "test.h"
 #include "wifi.h"
 #include "system.h"
+#include "state.h"
 
 /* The LED is connected on GPIO */
 #define BLINK_GPIO 4
@@ -184,10 +185,24 @@ void app_main(void)
     discovery_init();
 
     while(1) {
-        vTaskDelay(10);
-        gpio_set_level(BLINK_GPIO, 1);
-        vTaskDelay(10);
-        gpio_set_level(BLINK_GPIO, 0);
+        if (get_state() == STATE_OK)
+        {
+            vTaskDelay(10);
+            gpio_set_level(BLINK_GPIO, 1);
+            vTaskDelay(10);
+            gpio_set_level(BLINK_GPIO, 0);
+        } else
+        {
+            for (uint16_t i = 0; i < 20; i++)
+            {
+                vTaskDelay(3);
+                gpio_set_level(BLINK_GPIO, 1);
+                vTaskDelay(3);
+                gpio_set_level(BLINK_GPIO, 0);
+            }
+            vTaskDelay(40);
+        }
+        
     }
     esp_restart();
 }

--- a/main/cpx.c
+++ b/main/cpx.c
@@ -1,4 +1,5 @@
 #include "cpx.h"
+#include "state.h"
 #include "freertos/FreeRTOS.h"
 
 void cpxInitRoute(const CPXTarget_t source, const CPXTarget_t destination, const CPXFunction_t function, CPXRouting_t* route) {
@@ -17,6 +18,10 @@ void cpxRouteToPacked(const CPXRouting_t* route, CPXRoutingPacked_t* packed) {
 }
 
 void cpxPackedToRoute(const CPXRoutingPacked_t* packed, CPXRouting_t* route) {
+    if (CPX_VERSION != packed->version)
+    {
+        set_state(STATE_ERROR);
+    }
     assert(CPX_VERSION == packed->version);
 
     route->version = packed->version;

--- a/main/router.c
+++ b/main/router.c
@@ -39,6 +39,7 @@
 #include "uart_transport.h"
 #include "esp_transport.h"
 #include "wifi.h"
+#include "state.h"
 
 typedef struct {
   CPXRoutablePacket_t txp;
@@ -95,6 +96,10 @@ static void route(Receiver_t receive, CPXRoutablePacket_t* rxp, RouteContext_t* 
     receive(rxp);
 
     // The version should already be checked when we receive packets. Do it again to make sure.
+    if (CPX_VERSION != rxp->route.version)
+    {
+        set_state(STATE_ERROR);
+    }
     assert(CPX_VERSION == rxp->route.version);
 
     const CPXTarget_t source = rxp->route.source;

--- a/main/state.c
+++ b/main/state.c
@@ -1,0 +1,37 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * ESP deck firmware
+ *
+ * Copyright (C) 2022 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "state.h"
+
+State_t state = STATE_OK;
+
+State_t get_state()
+{
+    return state;
+}
+
+void set_state(State_t new_state)
+{
+    state = new_state;
+}

--- a/main/state.h
+++ b/main/state.h
@@ -1,0 +1,34 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * ESP deck firmware
+ *
+ * Copyright (C) 2022 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// This enum is used to identify the state
+typedef enum {
+  STATE_OK = 1, 
+  STATE_ERROR = 2, 
+} State_t;
+
+State_t get_state();
+void set_state(State_t new_state);


### PR DESCRIPTION
when cpx fails (at the moment only checks for version mismatch) the error message cannot be transmitted, but we want to show that something went wrong