### PR TITLE
Prevent AP setup with too short password

### DIFF
--- a/main/wifi.c
+++ b/main/wifi.c
@@ -235,8 +235,12 @@ static void wifi_ctrl(void* _param) {
           if (rxp.data[1] == 0) {
             wifi_init_sta(ssid, key);
           } else {
-            wifi_init_softap(ssid, key);
-          }          
+            if (strlen(key) < 8) {
+              ESP_LOGW(TAG, "Password too short, cannot initialize AP");
+            } else {
+              wifi_init_softap(ssid, key);
+            }
+          }
         } else {
           ESP_LOGW(TAG, "No SSID set, cannot start wifi");
         }

--- a/main/wifi.c
+++ b/main/wifi.c
@@ -235,7 +235,7 @@ static void wifi_ctrl(void* _param) {
           if (rxp.data[1] == 0) {
             wifi_init_sta(ssid, key);
           } else {
-            if (strlen(key) < 8) {
+            if (0 < strlen(key) && strlen(key) < 8) {
               ESP_LOGW(TAG, "Password too short, cannot initialize AP");
             } else {
               wifi_init_softap(ssid, key);


### PR DESCRIPTION
This PR ensures that the firmware does not attempt to set up an access point if the configured password is shorter than 8 characters. If an invalid password is detected, a warning is logged to inform the user (visible in cfclient console), and the AP setup is skipped.

Fixes #15